### PR TITLE
fix: product API bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,11 @@ curl-list-product: # Get vulnerabilities by product
 	curl -X GET \
 		'http://localhost:$(PORT)/api/v1/vulnerability/product?cpe_vendor=openstack&cpe_product=swift&version=1.4.6'
 
+.PHONY: curl-list-product-nginx
+curl-list-product-nginx: # Get nginx vulnerabilities
+	curl -X GET \
+		'http://localhost:$(PORT)/api/v1/vulnerability/product?cpe_vendor=f5&cpe_product=nginx&version=1.6.3'
+
 .PHONY: curl-import
 curl-import: # Import data to RISKEN Vulnerability DB
 	curl -X POST \

--- a/container/db/01_ddl.sql
+++ b/container/db/01_ddl.sql
@@ -12,9 +12,7 @@ CREATE TABLE cve (
     base_score DECIMAL(3,1),
     base_severity ENUM('NONE', 'LOW', 'MEDIUM', 'HIGH', 'CRITICAL', 'UNKNOWN'),
     vector_string VARCHAR(100),
-    cpe_part ENUM('a', 'o', 'h', 'UNKNOWN'),
-    cpe_vendor VARCHAR(100),
-    cpe_product TEXT,
+    cpe_product TEXT, -- List of CPE 'vender:product'
     cpe_target_sw TEXT,
     data JSON,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -22,7 +20,6 @@ CREATE TABLE cve (
     PRIMARY KEY(cve_id),
     INDEX idx_base_score(base_score),
     INDEX idx_base_severity(base_severity),
-    INDEX idx_cpe_vendor(cpe_vendor),
     FULLTEXT INDEX idx_cpe_product(cpe_product),
     FULLTEXT INDEX idx_cpe_target_sw(cpe_target_sw),
     FULLTEXT INDEX idx_description(description)

--- a/pkg/db/cve.go
+++ b/pkg/db/cve.go
@@ -18,8 +18,6 @@ func (c *Client) BulkUpsertCVE(ctx context.Context, cves []*model.CVE) error {
 			"base_score",
 			"base_severity",
 			"vector_string",
-			"cpe_part",
-			"cpe_vendor",
 			"cpe_product",
 			"cpe_target_sw",
 			"data",

--- a/pkg/model/cve.go
+++ b/pkg/model/cve.go
@@ -18,8 +18,6 @@ type CVE struct {
 	BaseScore        *float64   `json:"base_score,omitempty" gorm:"column:base_score"`
 	BaseSeverity     *string    `json:"base_severity,omitempty" gorm:"column:base_severity"`
 	VectorString     *string    `json:"vector_string,omitempty" gorm:"column:vector_string"`
-	CPEPart          *string    `json:"cpe_part,omitempty" gorm:"column:cpe_part"`
-	CPEVendor        *string    `json:"cpe_vendor,omitempty" gorm:"column:cpe_vendor"`
 	CPEProduct       *string    `json:"cpe_product,omitempty" gorm:"column:cpe_product"`
 	CPETargetSW      *string    `json:"cpe_target_sw,omitempty" gorm:"column:cpe_target_sw"`
 	Data             *string    `json:"data,omitempty" gorm:"column:data"`
@@ -110,8 +108,6 @@ func ConvertCVEJsonToCVE(cveJson *Vulnerability) (*CVE, error) {
 		BaseScore:        &cveJson.Impact.BaseMetricV3.CVSSV3.BaseScore,
 		BaseSeverity:     extractSeverityFromJSON(cveJson),
 		VectorString:     &cveJson.Impact.BaseMetricV3.CVSSV3.VectorString,
-		CPEPart:          cpeInfo.CPEPart,
-		CPEVendor:        cpeInfo.CPEVendor,
 		CPEProduct:       cpeInfo.CPEProduct,
 		CPETargetSW:      cpeInfo.CPETargetSW,
 		Data:             &data,
@@ -149,8 +145,8 @@ func extractSeverityFromJSON(cveJson *Vulnerability) *string {
 type CPEInfo struct {
 	CPEPrefix         *string `json:"cpe_prefix"`
 	CPEVersion        *string `json:"cpe_version"`
-	CPEPart           *string `json:"cpe_part" gorm:"column:cpe_part"`
-	CPEVendor         *string `json:"cpe_vendor" gorm:"column:cpe_vendor"`
+	CPEPart           *string `json:"cpe_part"`
+	CPEVendor         *string `json:"cpe_vendor"`
 	CPEProduct        *string `json:"cpe_product" gorm:"column:cpe_product"`
 	CPEProductVersion *string `json:"cpe_product_version"`
 	CPEUpdate         *string `json:"cpe_update"`
@@ -184,7 +180,11 @@ func extractCPEInfoFromJSON(cveJson *Vulnerability) *CPEInfo {
 				cpe.CPEVendor = tmpCpe.CPEVendor
 			}
 			if validCPEParam(tmpCpe.CPEProduct) {
-				cpeProductMap[*tmpCpe.CPEProduct] = true
+				if validCPEParam(tmpCpe.CPEVendor) {
+					cpeProductMap[*tmpCpe.CPEVendor+":"+*tmpCpe.CPEProduct] = true
+				} else {
+					cpeProductMap[*tmpCpe.CPEProduct] = true
+				}
 			}
 			if validCPEParam(tmpCpe.CPETargetSW) {
 				cpeTargetSWMap[*tmpCpe.CPETargetSW] = true

--- a/pkg/vulnerability/product.go
+++ b/pkg/vulnerability/product.go
@@ -62,13 +62,17 @@ func (c *Client) ListProductVulnerability(ctx context.Context, params model.List
 func buildProductWhere(params model.ListProductVulnerabilityRequest) (string, []any) {
 	where := "1=1"
 	var args []any
-	if params.CPEVendor != nil {
-		where += " and cpe_vendor = ?"
-		args = append(args, *params.CPEVendor)
+
+	product := ""
+	if params.CPEVendor != nil && params.CPEProduct != nil {
+		product = *params.CPEVendor + ":" + *params.CPEProduct
+	} else if params.CPEProduct != nil {
+		product = *params.CPEProduct
 	}
-	if params.CPEProduct != nil {
+
+	if product != "" {
 		where += " and MATCH(cpe_product) AGAINST(? IN BOOLEAN MODE)"
-		args = append(args, *params.CPEProduct)
+		args = append(args, product)
 	}
 	if params.CPETargetSw != nil {
 		where += " and MATCH(cpe_target_sw) AGAINST(? IN BOOLEAN MODE)"


### PR DESCRIPTION
プロダクトのAPIでVenderが複数パターン存在するケースを想定していなかったのでフィルターがうまく機能しないケースがありました。
`vendor:product` の形式でフィルターするように修正します。（データモデルの変更を伴います）