### PR TITLE
fix: download cve file with stream processing

### DIFF
--- a/pkg/cve/import.go
+++ b/pkg/cve/import.go
@@ -1,12 +1,10 @@
 package cve
 
 import (
-	"bytes"
 	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 
@@ -64,27 +62,18 @@ func (c *Client) DownloadCVEs(ctx context.Context, modified *bool, year *int) (*
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: url=%s, err=%w", downloadURL, err)
-	}
-
 	// Decompress
-	decompressedData, err := gzip.NewReader(bytes.NewReader(body))
+	decompressedData, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decompress: url=%s, err=%w", downloadURL, err)
 	}
 	defer decompressedData.Close()
 
-	unzippedBody, err := io.ReadAll(decompressedData)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read decompressed data: url=%s, err=%w", downloadURL, err)
-	}
-
+	// Use json.Decoder for streaming
+	decoder := json.NewDecoder(decompressedData)
 	var cveJSON model.CVEResponse
-	err = json.Unmarshal(unzippedBody, &cveJSON)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal: %w", err)
+	if err := decoder.Decode(&cveJSON); err != nil {
+		return nil, fmt.Errorf("failed to decode JSON: %w", err)
 	}
 	return &cveJSON, nil
 }


### PR DESCRIPTION
メモリ効率を考えてダウンロードファイルの処理をストリーミング処理するようにします